### PR TITLE
Removed String.includes usage from tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ test(async t => {
 	const binName = process.platform === 'win32' ? 'node.exe' : 'ava';
 	const list = await fn();
 
-	t.true(list.some(x => x.name.includes(binName)));
+	t.true(list.some(x => x.name.indexOf(binName) !== -1));
 	t.true(list.every(x =>
 		typeof x.pid === 'number' &&
 		typeof x.name === 'string' &&


### PR DESCRIPTION
It made tests fails on old node versions.
But maybe you want instead handle the problem in AVA and auto-include polyfills?