### PR TITLE
Add `ppid` property for macOS and Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function def(options = {}) {
 	const ret = {};
 	const flags = (options.all === false ? '' : 'a') + 'wwxo';
 
-	return Promise.all(['comm', 'args', '%cpu', '%mem'].map(cmd => {
+	return Promise.all(['comm', 'args', 'ppid', '%cpu', '%mem'].map(cmd => {
 		return pify(childProcess.execFile)('ps', [flags, `pid,${cmd}`], {
 			maxBuffer: TEN_MEGABYTE
 		}).then(stdout => {
@@ -42,11 +42,12 @@ function def(options = {}) {
 		// Filter out inconsistencies as there might be race
 		// issues due to differences in `ps` between the spawns
 		// TODO: Use `Object.entries` when targeting Node.js 8
-		return Object.keys(ret).filter(x => ret[x].comm && ret[x].args).map(x => {
+		return Object.keys(ret).filter(x => ret[x].comm && ret[x].args && ret[x].ppid && ret[x]['%cpu'] && ret[x]['%mem']).map(x => {
 			return {
 				pid: parseInt(x, 10),
 				name: path.basename(ret[x].comm),
 				cmd: ret[x].args,
+				ppid: parseInt(ret[x].ppid, 10),
 				cpu: ret[x]['%cpu'],
 				memory: ret[x]['%mem']
 			};

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ const psList = require('ps-list');
 
 psList().then(data => {
 	console.log(data);
-	//=> [{pid: 3213, name: 'node', cmd: 'node test.js', cpu: '0.1', memory: '1.5'}, ...]
+	//=> [{pid: 3213, name: 'node', cmd: 'node test.js', ppid: 1, cpu: '0.1', memory: '1.5'}, ...]
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ psList().then(data => {
 });
 ```
 
-> The `cpu` and `memory` percentage is not supported on Windows.
+> The `cpu` and `memory` percentage and the `ppid` are not supported on Windows.
 
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ psList().then(data => {
 });
 ```
 
-> The `cpu` and `memory` percentage and the `ppid` are not supported on Windows.
+> The `cpu`, `memory`, and `ppid` properties are not supported on Windows.
 
 
 ## API

--- a/test.js
+++ b/test.js
@@ -24,9 +24,7 @@ test('main', async t => {
 			)
 		);
 		t.true(
-			list.every(x =>
-				typeof x.ppid === 'number'
-			)
+			list.every(x => typeof x.ppid === 'number')
 		);
 	}
 });

--- a/test.js
+++ b/test.js
@@ -23,5 +23,10 @@ test('main', async t => {
 				typeof x.memory === 'string'
 			)
 		);
+		t.true(
+			list.every(x =>
+				typeof x.ppid === 'number'
+			)
+		);
 	}
 });


### PR DESCRIPTION
Included new test for ppid (checking if value is a number).
Mentioned Linux exclusivity in the readme.
Fixes #9 