### PR TITLE
Add full process name

### DIFF
--- a/test.js
+++ b/test.js
@@ -80,7 +80,7 @@ if (!isWindows) {
 
 		const list = await psList();
 
-		cases.forEach(c => c[0].kill());
+		cases.forEach(c => c[0].kill(9));
 
 		t.true(
 			cases.every(c =>

--- a/test.js
+++ b/test.js
@@ -30,7 +30,11 @@ test('main', async t => {
 });
 
 if (!isWindows) {
-	const spawnDummy = name => childProcess.spawn(`bash -c "exec -a '${name}' sleep 60"`, {shell: true});
+	const spawnDummy = name => childProcess.spawn(
+		`bash -c "exec -a '${name}' sleep 60"`,
+		[],
+		{shell: true}
+	);
 
 	test('process names', async t => {
 		const cases = [


### PR DESCRIPTION
Adds the full process name by splitting the `cmd` column into the `name with args` and the full process `name`. I think this is the least problematic solution because it involves no trickery with `/proc/$pid/exe` and the Unix file system. I also added some tests for it, let me know if you have any suggestions for more cases.

Resolves #1