### PR TITLE
Use one `ps` execution instead of multiple when possible

### DIFF
--- a/fixtures/sleep-forever.js
+++ b/fixtures/sleep-forever.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+'use strict';
+
+const sleep = () => {
+	setTimeout(sleep, 10000);
+};
+
+sleep();

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ const psOutputRegex = /^[ \t]*(\d+)[ \t]+(\d+)[ \t]+(\d+)[ \t]+(\d+\.\d+)[ \t]+(
 const nonWindowsSingleCall = async (options = {}) => {
 	const flags = options.all === false ? 'wwxo' : 'awwxo';
 
+	// TODO: Use the promise version of `execFile` when https://github.com/nodejs/node/issues/28244 is fixed
 	const [psPid, stdout] = await new Promise((resolve, reject) => {
 		const child = childProcess.execFile('ps', [flags, psFields], {maxBuffer: TEN_MEGABYTES}, (error, stdout) => {
 			if (error === null) {

--- a/index.js
+++ b/index.js
@@ -113,9 +113,9 @@ const nonWindowsSingleCall = async (options = {}) => {
 	}
 
 	const commLength = argsPosition - commPosition;
-	for (let i = 0; i < lines.length; i++) {
-		processes[i].name = lines[i].substr(commPosition, commLength).trim();
-		processes[i].cmd = lines[i].substr(argsPosition).trim();
+	for (const [i, line] of lines.entries()) {
+		processes[i].name = line.slice(commPosition, commPosition + commLength).trim();
+		processes[i].cmd = line.slice(argsPosition).trim();
 	}
 
 	processes.splice(psIndex, 1);

--- a/index.js
+++ b/index.js
@@ -58,10 +58,11 @@ const nonWindowsMultipleCalls = async (options = {}) => {
 		}));
 };
 
-const ERROR_MSG_PARSING_FAILED = 'ps output parsing failed';
+const ERROR_MESSAGE_PARSING_FAILED = 'ps output parsing failed';
 
 const psFields = 'pid,ppid,uid,%cpu,%mem,comm,args';
-// TODO Use named capture groups when targeting Node.js 10+
+
+// TODO: Use named capture groups when targeting Node.js 10
 const psOutputRegex = /^[ \t]*(\d+)[ \t]+(\d+)[ \t]+(\d+)[ \t]+(\d+\.\d+)[ \t]+(\d+\.\d+)[ \t]+/; // Groups: pid, ppid, uid, cpu, mem
 
 const nonWindowsSingleCall = async (options = {}) => {
@@ -87,7 +88,7 @@ const nonWindowsSingleCall = async (options = {}) => {
 	const processes = lines.map((line, i) => {
 		const match = psOutputRegex.exec(line);
 		if (match === null) {
-			throw new Error(ERROR_MSG_PARSING_FAILED);
+			throw new Error(ERROR_MESSAGE_PARSING_FAILED);
 		}
 
 		const process = {
@@ -109,7 +110,7 @@ const nonWindowsSingleCall = async (options = {}) => {
 	});
 
 	if (psIndex === undefined || commPosition === -1 || argsPosition === -1) {
-		throw new Error(ERROR_MSG_PARSING_FAILED);
+		throw new Error(ERROR_MESSAGE_PARSING_FAILED);
 	}
 
 	const commLength = argsPosition - commPosition;

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ const nonWindowsSingleCall = async (options = {}) => {
 const nonWindows = async (options = {}) => {
 	try {
 		return await nonWindowsSingleCall(options);
-	} catch (_) { // If the error is not parsing error it should manifest itself in multicall version too
+	} catch (_) { // If the error is not a parsing error, it should manifest itself in multicall version too
 		return nonWindowsMultipleCalls(options);
 	}
 };

--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
 import childProcess from 'child_process';
-
 import test from 'ava';
 import psList from '.';
 

--- a/test.js
+++ b/test.js
@@ -40,9 +40,13 @@ test('custom binary', async t => {
 	const sleepForever = childProcess.spawn(nodeBinaryName, args);
 
 	const list = await psList();
+
 	await new Promise(resolve => {
 		sleepForever.kill(9);
-		sleepForever.once('exit', () => resolve());
+
+		sleepForever.once('exit', () => {
+			resolve();
+		});
 	});
 
 	const record = list.find(process => process.pid === sleepForever.pid);
@@ -50,6 +54,7 @@ test('custom binary', async t => {
 	t.is(record.pid, sleepForever.pid);
 	t.is(record.name, nodeBinaryName);
 	t.is(record.ppid, process.pid);
+
 	if (!isWindows) {
 		t.is(record.cmd, `${nodeBinaryName} ${args.join(' ')}`);
 		t.is(record.uid, process.getuid());

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
+import childProcess from 'child_process';
+
 import test from 'ava';
 import psList from '.';
-import childProcess from 'child_process';
 
 const isWindows = process.platform === 'win32';
 
@@ -32,8 +33,8 @@ test('main', async t => {
 });
 
 test('some name', async t => {
-	let args = [];
-	for(let i = 0; i < 100; i++) {
+	const args = [];
+	for (let i = 0; i < 100; i++) {
 		args.push(`arg${i}`);
 	}
 

--- a/test.js
+++ b/test.js
@@ -32,13 +32,13 @@ test('main', async t => {
 	}
 });
 
-test('some name', async t => {
-	const args = [];
+test('custom binary', async t => {
+	const args = ['./fixtures/sleep-forever.js'];
 	for (let i = 0; i < 100; i++) {
 		args.push(`arg${i}`);
 	}
 
-	const sleepForever = childProcess.spawn('./fixtures/sleep-forever.js', args);
+	const sleepForever = childProcess.spawn(nodeBinaryName, args);
 
 	const list = await psList();
 	await new Promise(resolve => {
@@ -52,7 +52,7 @@ test('some name', async t => {
 	t.is(record.name, nodeBinaryName);
 	t.is(record.ppid, process.pid);
 	if (!isWindows) {
-		t.is(record.cmd, `${nodeBinaryName} ./fixtures/sleep-forever.js ${args.join(' ')}`);
+		t.is(record.cmd, `${nodeBinaryName} ${args.join(' ')}`);
 		t.is(record.uid, process.getuid());
 	}
 });

--- a/test.js
+++ b/test.js
@@ -1,13 +1,16 @@
 import test from 'ava';
 import psList from '.';
+import childProcess from 'child_process';
 
 const isWindows = process.platform === 'win32';
 
+const nodeBinaryName = isWindows ? 'node.exe' : 'node';
+const testBinaryName = isWindows ? nodeBinaryName : 'ava';
+
 test('main', async t => {
-	const binName = isWindows ? 'node.exe' : 'ava';
 	const list = await psList();
 
-	t.true(list.some(x => x.name.includes(binName)));
+	t.true(list.some(x => x.name.includes(testBinaryName)));
 	t.true(
 		list.every(x =>
 			typeof x.pid === 'number' &&
@@ -25,5 +28,30 @@ test('main', async t => {
 				typeof x.uid === 'number'
 			)
 		);
+	}
+});
+
+test('some name', async t => {
+	let args = [];
+	for(let i = 0; i < 100; i++) {
+		args.push(`arg${i}`);
+	}
+
+	const sleepForever = childProcess.spawn('./fixtures/sleep-forever.js', args);
+
+	const list = await psList();
+	await new Promise(resolve => {
+		sleepForever.kill(9);
+		sleepForever.once('exit', () => resolve());
+	});
+
+	const record = list.find(process => process.pid === sleepForever.pid);
+
+	t.is(record.pid, sleepForever.pid);
+	t.is(record.name, nodeBinaryName);
+	t.is(record.ppid, process.pid);
+	if (!isWindows) {
+		t.is(record.cmd, `${nodeBinaryName} ./fixtures/sleep-forever.js ${args.join(' ')}`);
+		t.is(record.uid, process.getuid());
 	}
 });


### PR DESCRIPTION
Ok, so I examined all `ps` implementations I found and it turns out they have one thing in common: they print comm and args values(doesn't apply to headers) left aligned.

Using this and the fact we run `ps` itself with controlled arguments, we parse `ps` output, find the line with `ps` itself, find out locations of comm and args and length of comm and use this info to parse all the lines. Afterwards, we exclude `ps` itself from resulting process list(which was a side-effect of previous implementation and probably is the right thing to do anyway).

Fixes #14