### PR TITLE
Use the promise version of `execFile`

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,16 +84,9 @@ const psOutputRegex = /^[ \t]*(?<pid>\d+)[ \t]+(?<ppid>\d+)[ \t]+(?<uid>\d+)[ \t
 const nonWindowsSingleCall = async (options = {}) => {
 	const flags = options.all === false ? 'wwxo' : 'awwxo';
 
-	// TODO: Use the promise version of `execFile` when https://github.com/nodejs/node/issues/28244 is fixed.
-	const [psPid, stdout] = await new Promise((resolve, reject) => {
-		const child = childProcess.execFile('ps', [flags, psFields], {maxBuffer: TEN_MEGABYTES}, (error, stdout) => {
-			if (error === null) {
-				resolve([child.pid, stdout]);
-			} else {
-				reject(error);
-			}
-		});
-	});
+	const promise = execFile('ps', [flags, psFields], {maxBuffer: TEN_MEGABYTES});
+	const {stdout} = await promise;
+	const {pid: psPid} = promise.child;
 
 	const lines = stdout.trim().split('\n');
 	lines.shift();


### PR DESCRIPTION
Using the sync method of execFile which results in a blockage of the main thread is no longer necessary because the upstream issue that introduced this has been fixed https://github.com/nodejs/node/pull/28325