### PR TITLE
Fix incorrect process name cutting on macos

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const ERROR_MESSAGE_PARSING_FAILED = 'ps output parsing failed';
 
 const psFields = 'pid,ppid,uid,%cpu,%mem,comm,args';
 
-const psOutputRegex = /^[ \t]*(?<pid>\d+)[ \t]+(?<ppid>\d+)[ \t]+(?<uid>[-\d]+)[ \t]+(?<cpu>\d+\.\d+)[ \t]+(?<memory>\d+\.\d+)[ \t]+/;
+const psOutputRegex = /^[ \t]*(?<pid>\d+)[ \t]+(?<ppid>\d+)[ \t]+(?<uid>[-\d]+)[ \t]+(?<cpu>\d+\.\d+)[ \t]+(?<memory>\d+\.\d+)[ \t]+(?<args>.*)?/;
 
 const nonWindowsSingleCall = async (options = {}) => {
 	const flags = options.all === false ? 'wwxo' : 'awwxo';

--- a/index.js
+++ b/index.js
@@ -96,8 +96,8 @@ const nonWindowsCall = async (options = {}) => {
 
 	const processCmds = {};
 	for (const line of psArgsLines) {
-		const [pid, cmd] = line.trim().split(' ');
-		processCmds[pid] = cmd;
+		const [pid, cmds] = line.trim().split(' ');
+		processCmds[pid] = cmds.join(' ');
 	}
 
 	const processes = psLines.map(line => {

--- a/index.js
+++ b/index.js
@@ -100,9 +100,7 @@ const nonWindowsCall = async (options = {}) => {
 		processNames[pid] = path.basename(cmd);
 	}
 
-	const psIndexes = [];
-
-	const processes = psLines.map((line, index) => {
+	const processes = psLines.map(line => {
 		const match = psOutputRegex.exec(line);
 
 		if (match === null) {
@@ -121,12 +119,8 @@ const nonWindowsCall = async (options = {}) => {
 			cmd: args,
 		};
 
-		if (psPids.has(processInfo.pid)) {
-			psIndexes.push(index);
-		}
-
 		return processInfo;
-	}).filter(processInfo => !psIndexes.includes(processInfo.pid));
+	}).filter(processInfo => !psPids.has(processInfo.pid));
 
 	return processes;
 };

--- a/index.js
+++ b/index.js
@@ -77,31 +77,39 @@ const nonWindowsMultipleCalls = async (options = {}) => {
 
 const ERROR_MESSAGE_PARSING_FAILED = 'ps output parsing failed';
 
-const psFields = 'pid,ppid,uid,%cpu,%mem,comm,args';
-
 const psOutputRegex = /^[ \t]*(?<pid>\d+)[ \t]+(?<ppid>\d+)[ \t]+(?<uid>[-\d]+)[ \t]+(?<cpu>\d+\.\d+)[ \t]+(?<memory>\d+\.\d+)[ \t]+(?<args>.*)?/;
 
-const nonWindowsSingleCall = async (options = {}) => {
+const nonWindowsCall = async (options = {}) => {
 	const flags = options.all === false ? 'wwxo' : 'awwxo';
 
-	const promise = execFile('ps', [flags, psFields], {maxBuffer: TEN_MEGABYTES});
-	const {stdout} = await promise;
-	const {pid: psPid} = promise.child;
+	const psPromises = [
+		execFile('ps', [flags, 'pid,ppid,uid,%cpu,%mem,args'], {maxBuffer: TEN_MEGABYTES}),
+		execFile('ps', [flags, 'pid,comm'], {maxBuffer: TEN_MEGABYTES}),
+	];
 
-	const lines = stdout.trim().split('\n');
-	lines.shift();
+	const [psLines, psCommLines] = (await Promise.all(psPromises)).map(({stdout}) => stdout.trim().split('\n'));
 
-	let psIndex;
-	let commPosition;
-	let argsPosition;
+	const psPids = new Set(psPromises.map(promise => promise.child.pid));
 
-	const processes = lines.map((line, index) => {
+	psLines.shift();
+	psCommLines.shift();
+
+	const processNames = {};
+	for (const line of psCommLines) {
+		const [pid, cmd] = line.trim().split(' ');
+		processNames[pid] = path.basename(cmd);
+	}
+
+	const psIndexes = [];
+
+	const processes = psLines.map((line, index) => {
 		const match = psOutputRegex.exec(line);
+
 		if (match === null) {
 			throw new Error(ERROR_MESSAGE_PARSING_FAILED);
 		}
 
-		const {pid, ppid, uid, cpu, memory} = match.groups;
+		const {pid, ppid, uid, cpu, memory, args} = match.groups;
 
 		const processInfo = {
 			pid: Number.parseInt(pid, 10),
@@ -109,36 +117,23 @@ const nonWindowsSingleCall = async (options = {}) => {
 			uid: Number.parseInt(uid, 10),
 			cpu: Number.parseFloat(cpu),
 			memory: Number.parseFloat(memory),
-			name: undefined,
-			cmd: undefined,
+			name: processNames[pid],
+			cmd: args,
 		};
 
-		if (processInfo.pid === psPid) {
-			psIndex = index;
-			commPosition = line.indexOf('ps', match[0].length);
-			argsPosition = line.indexOf('ps', commPosition + 2);
+		if (psPids.has(processInfo.pid)) {
+			psIndexes.push(index);
 		}
 
 		return processInfo;
-	});
+	}).filter(processInfo => !psIndexes.includes(processInfo.pid));
 
-	if (psIndex === undefined || commPosition === -1 || argsPosition === -1) {
-		throw new Error(ERROR_MESSAGE_PARSING_FAILED);
-	}
-
-	const commLength = argsPosition - commPosition;
-	for (const [index, line] of lines.entries()) {
-		processes[index].name = line.slice(commPosition, commPosition + commLength).trim();
-		processes[index].cmd = line.slice(argsPosition).trim();
-	}
-
-	processes.splice(psIndex, 1);
 	return processes;
 };
 
 const nonWindows = async (options = {}) => {
 	try {
-		return await nonWindowsSingleCall(options);
+		return await nonWindowsCall(options);
 	} catch { // If the error is not a parsing error, it should manifest itself in multicall version too.
 		return nonWindowsMultipleCalls(options);
 	}

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const ERROR_MESSAGE_PARSING_FAILED = 'ps output parsing failed';
 
 const psFields = 'pid,ppid,uid,%cpu,%mem,comm,args';
 
-const psOutputRegex = /^[ \t]*(?<pid>\d+)[ \t]+(?<ppid>\d+)[ \t]+(?<uid>\d+)[ \t]+(?<cpu>\d+\.\d+)[ \t]+(?<memory>\d+\.\d+)[ \t]+/;
+const psOutputRegex = /^[ \t]*(?<pid>\d+)[ \t]+(?<ppid>\d+)[ \t]+(?<uid>[-\d]+)[ \t]+(?<cpu>\d+\.\d+)[ \t]+(?<memory>\d+\.\d+)[ \t]+/;
 
 const nonWindowsSingleCall = async (options = {}) => {
 	const flags = options.all === false ? 'wwxo' : 'awwxo';


### PR DESCRIPTION
I found `ps-list` returns incorrect process name while working on https://github.com/sindresorhus/fkill-cli/pull/83

I think it is broken in ps-list@7.0.0 (https://github.com/sindresorhus/ps-list/blob/v7.0.0/index.js#L125).

This PR will fix https://github.com/sindresorhus/fkill-cli/issues/78.

Only tested in macOS yet.

## Before

![2022-11-21_19-07-06](https://user-images.githubusercontent.com/18283033/203023160-c57d6060-825a-4537-b36d-07ca7bad195f.png)

## After

![afte](https://user-images.githubusercontent.com/18283033/203023001-84c045b0-14af-40e8-bc74-8d89d69af3b2.gif)


---

Fixes #49
